### PR TITLE
Upgrade dependencies and refactor version checking

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -5,10 +5,13 @@ plugins {
 }
 
 java {
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
     withSourcesJar()
     withJavadocJar()
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+}
+
+tasks.compileJava {
+    options.release.set(21)
 }
 
 group = rootProject.group
@@ -16,8 +19,9 @@ version = rootProject.version
 
 repositories {
     mavenCentral()
-    maven("https://repo.thenextlvl.net/releases")
+    maven("https://maven.enginehub.org/repo/")
     maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.thenextlvl.net/releases")
 }
 
 dependencies {
@@ -26,7 +30,10 @@ dependencies {
     compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
 
     compileOnlyApi(platform("com.intellectualsites.bom:bom-newest:1.45"))
-    compileOnlyApi("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit")
+    compileOnlyApi("com.fastasyncworldedit:FastAsyncWorldEdit-Core") { isTransitive = false }
+    compileOnlyApi("com.fastasyncworldedit:FastAsyncWorldEdit-Bukkit") {
+        exclude("org.jetbrains", "annotations")
+    }
 
     api("net.thenextlvl.core:i18n:1.0.20")
     api("net.thenextlvl.core:paper:1.5.3")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,10 +26,9 @@ repositories {
 dependencies {
     compileOnly("org.projectlombok:lombok:1.18.36")
     compileOnly("net.thenextlvl.core:annotations:2.0.1")
-    compileOnly("io.papermc.paper:paper-api:1.21.1-R0.1-SNAPSHOT")
+    compileOnly("io.papermc.paper:paper-api:1.21.3-R0.1-SNAPSHOT")
 
     implementation("org.bstats:bstats-bukkit:3.1.0")
-    implementation("com.github.xmrafonso:hangar4j:1.2.2")
 
     api("net.thenextlvl.core:adapters:1.0.9")
 
@@ -69,8 +68,11 @@ paper {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21
+    toolchain.languageVersion = JavaLanguageVersion.of(21)
+}
+
+tasks.compileJava {
+    options.release.set(21)
 }
 
 tasks.shadowJar {

--- a/src/main/java/net/thenextlvl/gopaint/GoPaintPlugin.java
+++ b/src/main/java/net/thenextlvl/gopaint/GoPaintPlugin.java
@@ -37,7 +37,6 @@ import org.bukkit.plugin.java.JavaPlugin;
 import java.io.File;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Set;
 
 @Accessors(fluent = true)
@@ -70,7 +69,7 @@ public class GoPaintPlugin extends JavaPlugin implements GoPaintProvider {
             .create()
     ).validate().save();
 
-    private final VersionChecker versionChecker = new VersionChecker();
+    private final VersionChecker versionChecker = new VersionChecker(this);
     private final Metrics metrics = new Metrics(this, 22279);
 
     public GoPaintPlugin() {
@@ -78,20 +77,8 @@ public class GoPaintPlugin extends JavaPlugin implements GoPaintProvider {
     }
 
     @Override
-    @SuppressWarnings("UnstableApiUsage")
     public void onLoad() {
-        versionChecker.retrieveLatestSupportedVersion(latest -> latest.ifPresent(version -> {
-            var running = VersionChecker.Version.parse(getPluginMeta().getVersion());
-            if (version.equals(running)) {
-                getComponentLogger().info("You are running the latest version of goPaintAdvanced");
-            } else if (version.compareTo(Objects.requireNonNull(running)) > 0) {
-                getComponentLogger().warn("An update for goPaintAdvanced is available");
-                getComponentLogger().warn("You are running version {}, the latest supported version is {}", running, version);
-                getComponentLogger().warn("Update at https://modrinth.com/plugin/gopaintadvanced or https://hangar.papermc.io/TheNextLvl/goPaintAdvanced");
-            } else {
-                getComponentLogger().warn("You are running a snapshot version of goPaintAdvanced");
-            }
-        }));
+        versionChecker.checkVersion();
     }
 
     @Override

--- a/src/main/java/net/thenextlvl/gopaint/version/VersionChecker.java
+++ b/src/main/java/net/thenextlvl/gopaint/version/VersionChecker.java
@@ -1,62 +1,17 @@
 package net.thenextlvl.gopaint.version;
 
-import me.mrafonso.hangar4j.HangarClient;
-import me.mrafonso.hangar4j.impl.Platform;
-import me.mrafonso.hangar4j.impl.version.HangarVersion;
-import org.bukkit.Bukkit;
-import org.jetbrains.annotations.NotNull;
+import core.paper.version.PaperHangarVersionChecker;
+import core.version.SemanticVersion;
+import org.bukkit.plugin.Plugin;
 import org.jetbrains.annotations.Nullable;
 
-import java.util.Objects;
-import java.util.Optional;
-import java.util.function.Consumer;
-
-public class VersionChecker {
-    private final HangarClient hangarClient = new HangarClient(null);
-
-    public void retrieveLatestSupportedVersion(Consumer<Optional<Version>> success) {
-        Objects.requireNonNull(hangarClient.getVersions("goPaintAdvanced"))
-                .thenAcceptAsync(versions -> success.accept(versions.result().stream()
-                        .filter(this::isSupported)
-                        .map(Version::parse)
-                        .filter(Objects::nonNull)
-                        .max(Version::compareTo)));
+public class VersionChecker extends PaperHangarVersionChecker<SemanticVersion> {
+    public VersionChecker(Plugin plugin) {
+        super(plugin, "TheNextLvl", "goPaintAdvanced");
     }
 
-    private boolean isSupported(HangarVersion version) {
-        return version.platformDependencies().get(Platform.PAPER)
-                .contains(Bukkit.getMinecraftVersion());
-    }
-
-    public record Version(int major, int minor, int build) implements Comparable<Version> {
-
-        public static @Nullable Version parse(HangarVersion version) {
-            return parse(version.name());
-        }
-
-        public static @Nullable Version parse(String string) {
-            try {
-                var split = string.split("\\.", 3);
-                return new Version(
-                        Integer.parseInt(split[0]),
-                        Integer.parseInt(split[1]),
-                        Integer.parseInt(split[2])
-                );
-            } catch (Exception ignored) {
-                return null;
-            }
-        }
-
-        @Override
-        public int compareTo(@NotNull Version version) {
-            return major() != version.major() ? Integer.compare(major(), version.major())
-                    : minor() != version.minor() ? Integer.compare(minor(), version.minor())
-                    : Integer.compare(build(), version.build());
-        }
-
-        @Override
-        public String toString() {
-            return major() + "." + minor() + "." + build();
-        }
+    @Override
+    public @Nullable SemanticVersion parseVersion(String version) {
+        return SemanticVersion.parse(version);
     }
 }


### PR DESCRIPTION
Updated to newer versions of dependencies, notably upgrading to `paper-api:1.21.3-R0.1-SNAPSHOT`. Refactored the `VersionChecker` class to utilize `PaperHangarVersionChecker` for improved version management and removed unnecessary dependencies and code. Adjusted Java toolchain setup and compile options for better compatibility and build consistency.