### PR TITLE
Refactor accessor calls to method references

### DIFF
--- a/api/src/main/java/net/thenextlvl/gopaint/api/brush/mask/VisibleMask.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/brush/mask/VisibleMask.java
@@ -12,19 +12,19 @@ public record VisibleMask(Extent extent, Vector3 viewPoint) implements Mask {
     public boolean test(BlockVector3 vector) {
 
         var location = new MutableVector3(
-                vector.getX(),
-                vector.getY(),
-                vector.getZ()
+                vector.x(),
+                vector.y(),
+                vector.z()
         );
 
-        var distanceX = viewPoint().getX() - location.getX();
-        var distanceY = viewPoint().getY() - location.getY();
-        var distanceZ = viewPoint().getZ() - location.getZ();
+        var distanceX = viewPoint().x() - location.x();
+        var distanceY = viewPoint().y() - location.y();
+        var distanceZ = viewPoint().z() - location.z();
 
         location.setComponents(
-                location.getX() + (distanceX > 1 ? 1 : distanceX > 0 ? 0.5 : 0),
-                location.getY() + (distanceY > 1 ? 1 : distanceY > 0 ? 0.5 : 0),
-                location.getZ() + (distanceZ > 1 ? 1 : distanceZ > 0 ? 0.5 : 0)
+                location.x() + (distanceX > 1 ? 1 : distanceX > 0 ? 0.5 : 0),
+                location.y() + (distanceY > 1 ? 1 : distanceY > 0 ? 0.5 : 0),
+                location.z() + (distanceZ > 1 ? 1 : distanceZ > 0 ? 0.5 : 0)
         );
 
         var distance = location.distance(viewPoint());

--- a/api/src/main/java/net/thenextlvl/gopaint/api/math/Height.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/math/Height.java
@@ -30,14 +30,14 @@ public class Height {
      */
     public static int getNearestNonEmptyBlock(Block block) {
         if (block.material().isAir()) {
-            for (var y = block.vector().getY(); y >= block.world().getMinY(); y--) {
-                if (block.world().getBlock(block.vector().getX(), y, block.vector().getZ()).isAir()) continue;
+            for (var y = block.vector().y(); y >= block.world().getMinY(); y--) {
+                if (block.world().getBlock(block.vector().x(), y, block.vector().z()).isAir()) continue;
                 return y + 1;
             }
             return block.world().getMinY();
         } else {
-            for (var y = block.vector().getY(); y <= block.world().getMaxY(); y++) {
-                if (!block.world().getBlock(block.vector().getX(), y, block.vector().getZ()).isAir()) continue;
+            for (var y = block.vector().y(); y <= block.world().getMaxY(); y++) {
+                if (!block.world().getBlock(block.vector().x(), y, block.vector().z()).isAir()) continue;
                 return y;
             }
             return block.world().getMaxY();

--- a/api/src/main/java/net/thenextlvl/gopaint/api/math/Sphere.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/math/Sphere.java
@@ -30,9 +30,9 @@ public class Sphere {
         var loc1 = position.subtract((int) radius, (int) radius, (int) radius);
         var loc2 = position.add((int) radius, (int) radius, (int) radius);
 
-        for (var x = loc1.getX(); x <= loc2.getX(); x++) {
-            for (var y = loc1.getY(); y <= loc2.getY(); y++) {
-                for (var z = loc1.getZ(); z <= loc2.getZ(); z++) {
+        for (var x = loc1.x(); x <= loc2.x(); x++) {
+            for (var y = loc1.y(); y <= loc2.y(); y++) {
+                for (var z = loc1.z(); z <= loc2.z(); z++) {
                     var vector3 = BlockVector3.at(x, y, z);
                     if (vector3.distance(position) >= radius) continue;
                     vectors.add(vector3);

--- a/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSpline.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSpline.java
@@ -72,27 +72,27 @@ public class BezierSpline {
     public void calculateControlPoints() {
         if (segments.length == 0) return;
 
-        var xFlat = Arrays.stream(knots).allMatch(l -> l.getBlockX() == knots[0].getX())
-                ? OptionalDouble.of(knots[0].getX()) : OptionalDouble.empty();
-        var yFlat = Arrays.stream(knots).allMatch(l -> l.getBlockY() == knots[0].getY())
-                ? OptionalDouble.of(knots[0].getY()) : OptionalDouble.empty();
-        var zFlat = Arrays.stream(knots).allMatch(l -> l.getBlockZ() == knots[0].getZ())
-                ? OptionalDouble.of(knots[0].getZ()) : OptionalDouble.empty();
+        var xFlat = Arrays.stream(knots).allMatch(l -> l.x() == knots[0].x())
+                ? OptionalDouble.of(knots[0].x()) : OptionalDouble.empty();
+        var yFlat = Arrays.stream(knots).allMatch(l -> l.y() == knots[0].y())
+                ? OptionalDouble.of(knots[0].y()) : OptionalDouble.empty();
+        var zFlat = Arrays.stream(knots).allMatch(l -> l.z() == knots[0].z())
+                ? OptionalDouble.of(knots[0].z()) : OptionalDouble.empty();
 
         if (segments.length == 1) {
             var midpoint = new MutableBlockVector3(0, 0, 0);
-            midpoint.mutX((segments[0].getStartPoint().getX() + segments[0].getEndPoint().getX()) / 2);
-            midpoint.mutY((segments[0].getStartPoint().getY() + segments[0].getEndPoint().getY()) / 2);
-            midpoint.mutZ((segments[0].getStartPoint().getZ() + segments[0].getEndPoint().getZ()) / 2);
+            midpoint.mutX((segments[0].getStartPoint().x() + segments[0].getEndPoint().x()) / 2);
+            midpoint.mutY((segments[0].getStartPoint().y() + segments[0].getEndPoint().y()) / 2);
+            midpoint.mutZ((segments[0].getStartPoint().z() + segments[0].getEndPoint().z()) / 2);
             segments[0].setIntermediatePoint1(midpoint);
             segments[0].setIntermediatePoint2(new MutableBlockVector3(midpoint));
         } else {
             segments[0].setCoefficient1(0);
             segments[0].setCoefficient2(2);
             segments[0].setCoefficient3(1);
-            segments[0].getResult().mutX(knots[0].getX() + 2 * knots[1].getX());
-            segments[0].getResult().mutY(knots[0].getY() + 2 * knots[1].getY());
-            segments[0].getResult().mutZ(knots[0].getZ() + 2 * knots[1].getZ());
+            segments[0].getResult().mutX(knots[0].x() + 2 * knots[1].x());
+            segments[0].getResult().mutY(knots[0].y() + 2 * knots[1].y());
+            segments[0].getResult().mutZ(knots[0].z() + 2 * knots[1].z());
 
             int n = knots.length - 1;
             float m;
@@ -101,44 +101,44 @@ public class BezierSpline {
                 segments[i].setCoefficient1(1);
                 segments[i].setCoefficient2(4);
                 segments[i].setCoefficient3(1);
-                segments[i].getResult().mutX(4 * knots[i].getX() + 2 * knots[i + 1].getX());
-                segments[i].getResult().mutY(4 * knots[i].getY() + 2 * knots[i + 1].getY());
-                segments[i].getResult().mutZ(4 * knots[i].getZ() + 2 * knots[i + 1].getZ());
+                segments[i].getResult().mutX(4 * knots[i].x() + 2 * knots[i + 1].x());
+                segments[i].getResult().mutY(4 * knots[i].y() + 2 * knots[i + 1].y());
+                segments[i].getResult().mutZ(4 * knots[i].z() + 2 * knots[i + 1].z());
             }
 
             segments[n - 1].setCoefficient1(2);
             segments[n - 1].setCoefficient2(7);
             segments[n - 1].setCoefficient3(0);
-            segments[n - 1].getResult().mutX(8 * knots[n - 1].getX() + knots[n].getX());
-            segments[n - 1].getResult().mutY(8 * knots[n - 1].getY() + knots[n].getY());
-            segments[n - 1].getResult().mutZ(8 * knots[n - 1].getZ() + knots[n].getZ());
+            segments[n - 1].getResult().mutX(8 * knots[n - 1].x() + knots[n].x());
+            segments[n - 1].getResult().mutY(8 * knots[n - 1].y() + knots[n].y());
+            segments[n - 1].getResult().mutZ(8 * knots[n - 1].z() + knots[n].z());
 
             for (int i = 1; i < n; i++) {
                 m = segments[i].getCoefficient1() / segments[i - 1].getCoefficient2();
                 segments[i].setCoefficient2(segments[i].getCoefficient2() - m * segments[i - 1].getCoefficient3());
-                segments[i].getResult().mutX(segments[i].getResult().getX() - m * segments[i - 1].getResult().getX());
-                segments[i].getResult().mutY(segments[i].getResult().getY() - m * segments[i - 1].getResult().getY());
-                segments[i].getResult().mutZ(segments[i].getResult().getZ() - m * segments[i - 1].getResult().getZ());
+                segments[i].getResult().mutX(segments[i].getResult().x() - m * segments[i - 1].getResult().x());
+                segments[i].getResult().mutY(segments[i].getResult().y() - m * segments[i - 1].getResult().y());
+                segments[i].getResult().mutZ(segments[i].getResult().z() - m * segments[i - 1].getResult().z());
             }
 
-            segments[n - 1].getIntermediatePoint1().mutX(segments[n - 1].getResult().getX() / segments[n - 1].getCoefficient2());
-            segments[n - 1].getIntermediatePoint1().mutY(segments[n - 1].getResult().getY() / segments[n - 1].getCoefficient2());
-            segments[n - 1].getIntermediatePoint1().mutZ(segments[n - 1].getResult().getZ() / segments[n - 1].getCoefficient2());
+            segments[n - 1].getIntermediatePoint1().mutX(segments[n - 1].getResult().x() / segments[n - 1].getCoefficient2());
+            segments[n - 1].getIntermediatePoint1().mutY(segments[n - 1].getResult().y() / segments[n - 1].getCoefficient2());
+            segments[n - 1].getIntermediatePoint1().mutZ(segments[n - 1].getResult().z() / segments[n - 1].getCoefficient2());
 
             for (int i = n - 2; i >= 0; i--) {
-                segments[i].getIntermediatePoint1().mutX((segments[i].getResult().getX() - segments[i].getCoefficient3() * segments[i + 1].getIntermediatePoint1().getX()) / segments[i].getCoefficient2());
-                segments[i].getIntermediatePoint1().mutY((segments[i].getResult().getY() - segments[i].getCoefficient3() * segments[i + 1].getIntermediatePoint1().getY()) / segments[i].getCoefficient2());
-                segments[i].getIntermediatePoint1().mutZ((segments[i].getResult().getZ() - segments[i].getCoefficient3() * segments[i + 1].getIntermediatePoint1().getZ()) / segments[i].getCoefficient2());
+                segments[i].getIntermediatePoint1().mutX((segments[i].getResult().x() - segments[i].getCoefficient3() * segments[i + 1].getIntermediatePoint1().x()) / segments[i].getCoefficient2());
+                segments[i].getIntermediatePoint1().mutY((segments[i].getResult().y() - segments[i].getCoefficient3() * segments[i + 1].getIntermediatePoint1().y()) / segments[i].getCoefficient2());
+                segments[i].getIntermediatePoint1().mutZ((segments[i].getResult().z() - segments[i].getCoefficient3() * segments[i + 1].getIntermediatePoint1().z()) / segments[i].getCoefficient2());
             }
 
             for (int i = 0; i < n - 1; i++) {
-                segments[i].getIntermediatePoint2().mutX(2 * knots[i + 1].getX() - segments[i + 1].getIntermediatePoint1().getX());
-                segments[i].getIntermediatePoint2().mutY(2 * knots[i + 1].getY() - segments[i + 1].getIntermediatePoint1().getY());
-                segments[i].getIntermediatePoint2().mutZ(2 * knots[i + 1].getZ() - segments[i + 1].getIntermediatePoint1().getZ());
+                segments[i].getIntermediatePoint2().mutX(2 * knots[i + 1].x() - segments[i + 1].getIntermediatePoint1().x());
+                segments[i].getIntermediatePoint2().mutY(2 * knots[i + 1].y() - segments[i + 1].getIntermediatePoint1().y());
+                segments[i].getIntermediatePoint2().mutZ(2 * knots[i + 1].z() - segments[i + 1].getIntermediatePoint1().z());
             }
-            segments[n - 1].getIntermediatePoint2().mutX(0.5 * (knots[n].getX() + segments[n - 1].getIntermediatePoint1().getX()));
-            segments[n - 1].getIntermediatePoint2().mutY(0.5 * (knots[n].getY() + segments[n - 1].getIntermediatePoint1().getY()));
-            segments[n - 1].getIntermediatePoint2().mutZ(0.5 * (knots[n].getZ() + segments[n - 1].getIntermediatePoint1().getZ()));
+            segments[n - 1].getIntermediatePoint2().mutX(0.5 * (knots[n].x() + segments[n - 1].getIntermediatePoint1().x()));
+            segments[n - 1].getIntermediatePoint2().mutY(0.5 * (knots[n].y() + segments[n - 1].getIntermediatePoint1().y()));
+            segments[n - 1].getIntermediatePoint2().mutZ(0.5 * (knots[n].z() + segments[n - 1].getIntermediatePoint1().z()));
         }
 
         xFlat.ifPresent(value -> Arrays.stream(segments).forEach(segment -> segment.setX(value)));

--- a/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSplineSegment.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSplineSegment.java
@@ -86,13 +86,13 @@ public class BezierSplineSegment {
     @Contract(pure = true)
     public BlockVector3 getPoint(double factor) {
         var x = Objects.requireNonNullElseGet(xFlat, () -> calculatePoint(
-                factor, startPoint.getX(), intermediatePoint1.getX(), intermediatePoint2.getX(), endPoint.getX()
+                factor, startPoint.x(), intermediatePoint1.x(), intermediatePoint2.x(), endPoint.x()
         ));
         var y = Objects.requireNonNullElseGet(yFlat, () -> calculatePoint(
-                factor, startPoint.getY(), intermediatePoint1.getY(), intermediatePoint2.getY(), endPoint.getY()
+                factor, startPoint.y(), intermediatePoint1.y(), intermediatePoint2.y(), endPoint.y()
         ));
         var z = Objects.requireNonNullElseGet(zFlat, () -> calculatePoint(
-                factor, startPoint.getZ(), intermediatePoint1.getZ(), intermediatePoint2.getZ(), endPoint.getZ()
+                factor, startPoint.z(), intermediatePoint1.z(), intermediatePoint2.z(), endPoint.z()
         ));
         return BlockVector3.at(x, y, z);
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/pattern/GradientPattern.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/pattern/GradientPattern.java
@@ -22,7 +22,7 @@ public record GradientPattern(
     @Override
     public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
         if (settings().getRandom().nextDouble() <= getRate(set)) return false;
-        return set.setBlock(extent, getRandomBlockState(set.getY()));
+        return set.setBlock(extent, getRandomBlockState(set.y()));
     }
 
     public BlockState getRandomBlockState(int altitude) {
@@ -33,7 +33,7 @@ public record GradientPattern(
 
     private int getRandom(int altitude) {
         if (settings().getBlocks().size() == 1) return 1;
-        var y = position().getY() - (settings().getBrushSize() / 2d);
+        var y = position().y() - (settings().getBrushSize() / 2d);
         var _y = (altitude - y) / settings().getBrushSize() * settings().getBlocks().size();
         return (int) (_y + (settings().getRandom().nextDouble() * 2 - 1) * (settings().getMixingStrength() / 100d));
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/PaintBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/PaintBrush.java
@@ -75,9 +75,9 @@ public class PaintBrush extends PatternBrush {
 
         if (!bukkit.getPlayer().isSneaking()) {
             provider.bundle().sendMessage(bukkit.getPlayer(), "brush.paint.point.set",
-                    Placeholder.parsed("x", String.valueOf(position.getX())),
-                    Placeholder.parsed("y", String.valueOf(position.getY())),
-                    Placeholder.parsed("z", String.valueOf(position.getZ())),
+                    Placeholder.parsed("x", String.valueOf(position.x())),
+                    Placeholder.parsed("y", String.valueOf(position.y())),
+                    Placeholder.parsed("z", String.valueOf(position.z())),
                     Placeholder.parsed("point", String.valueOf(selectedPoints.get(id).size()))
             );
             return;
@@ -98,11 +98,11 @@ public class PaintBrush extends PatternBrush {
                     pattern.random(settings.getRandom().nextInt(settings.getBlocks().size()));
 
                     var curve = new LinkedList<MutableBlockVector3>();
-                    curve.add(MutableBlockVector3.at(vector3.getX(), vector3.getY(), vector3.getZ()));
+                    curve.add(MutableBlockVector3.at(vector3.x(), vector3.y(), vector3.z()));
                     vectors.stream().skip(1).map(location -> MutableBlockVector3.at(
-                            vector3.getX() + location.getX() - first.getX(),
-                            vector3.getY() + location.getY() - first.getY(),
-                            vector3.getZ() + location.getZ() - first.getZ()
+                            vector3.x() + location.x() - first.x(),
+                            vector3.y() + location.y() - first.y(),
+                            vector3.z() + location.z() - first.z()
                     )).forEach(curve::add);
 
                     var spline = new BezierSpline(curve);


### PR DESCRIPTION
Updated all vector and block coordinate access calls to use direct method references instead of getter methods. This simplifies the code and aligns with modern coding practices for cleaner and more readable code.