### PR TITLE
Update PaperMC repository URL in build scripts

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -20,7 +20,7 @@ version = rootProject.version
 repositories {
     mavenCentral()
     maven("https://maven.enginehub.org/repo/")
-    maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.papermc.io/repository/maven-public/")
     maven("https://repo.thenextlvl.net/releases")
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,7 +20,7 @@ repositories {
     mavenCentral()
     maven("https://jitpack.io")
     maven("https://repo.thenextlvl.net/releases")
-    maven("https://papermc.io/repo/repository/maven-public/")
+    maven("https://repo.papermc.io/repository/maven-public/")
 }
 
 dependencies {


### PR DESCRIPTION
Replaces the outdated PaperMC Maven repository URL with the correct one in both `build.gradle.kts` and `api/build.gradle.kts`. This ensures that dependencies are resolved correctly from the updated repository location.