### PR TITLE
Remove Lombok dependency and inline generated methods

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -25,7 +25,6 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.projectlombok:lombok:1.18.36")
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
 
     compileOnlyApi(platform("com.intellectualsites.bom:bom-newest:1.51"))
@@ -36,8 +35,6 @@ dependencies {
 
     api("net.thenextlvl.core:i18n:1.0.20")
     api("net.thenextlvl.core:paper:2.0.3")
-
-    annotationProcessor("org.projectlombok:lombok:1.18.36")
 }
 
 publishing {

--- a/api/src/main/java/net/thenextlvl/gopaint/api/brush/PatternBrush.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/brush/PatternBrush.java
@@ -6,11 +6,6 @@ import com.sk89q.worldedit.command.tool.brush.Brush;
 import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.ToString;
-import lombok.experimental.Accessors;
 import net.kyori.adventure.audience.Audience;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.key.Keyed;
@@ -19,14 +14,12 @@ import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 
+import java.util.Objects;
+
 /**
  * This interface represents a brush used for painting blocks in a world.
  */
-@Getter
-@ToString
 @NullMarked
-@EqualsAndHashCode
-@RequiredArgsConstructor
 public abstract class PatternBrush implements Comparable<PatternBrush>, Keyed, Brush {
     /**
      * Retrieves the base64 head value.
@@ -35,7 +28,12 @@ public abstract class PatternBrush implements Comparable<PatternBrush>, Keyed, B
     /**
      * The key that identifies this brush
      */
-    private final @Accessors(fluent = true) Key key;
+    private final Key key;
+
+    public PatternBrush(String headValue, Key key) {
+        this.headValue = headValue;
+        this.key = key;
+    }
 
     /**
      * Retrieves the localized name of this brush.
@@ -76,8 +74,36 @@ public abstract class PatternBrush implements Comparable<PatternBrush>, Keyed, B
     @Override
     public abstract void build(EditSession session, BlockVector3 position, Pattern pattern, double size) throws MaxChangedBlocksException;
 
+    public String getHeadValue() {
+        return headValue;
+    }
+
+    @Override
+    public Key key() {
+        return key;
+    }
+
     @Override
     public int compareTo(@NonNull PatternBrush brush) {
         return key().compareTo(brush.key());
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        PatternBrush that = (PatternBrush) o;
+        return Objects.equals(key, that.key);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(key);
+    }
+
+    @Override
+    public String toString() {
+        return "PatternBrush{" +
+               "key=" + key +
+               '}';
     }
 }

--- a/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSpline.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSpline.java
@@ -20,7 +20,6 @@ package net.thenextlvl.gopaint.api.math.curve;
 
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
 import com.sk89q.worldedit.math.BlockVector3;
-import lombok.Getter;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 
@@ -28,7 +27,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.OptionalDouble;
 
-@Getter
 @NullMarked
 public class BezierSpline {
 
@@ -146,6 +144,18 @@ public class BezierSpline {
         xFlat.ifPresent(value -> Arrays.stream(segments).forEach(segment -> segment.setX(value)));
         yFlat.ifPresent(value -> Arrays.stream(segments).forEach(segment -> segment.setY(value)));
         zFlat.ifPresent(value -> Arrays.stream(segments).forEach(segment -> segment.setZ(value)));
+    }
+
+    public BezierSplineSegment[] getSegments() {
+        return segments;
+    }
+
+    public MutableBlockVector3[] getKnots() {
+        return knots;
+    }
+
+    public double getCurveLength() {
+        return curveLength;
     }
 
     @Override

--- a/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSplineSegment.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/math/curve/BezierSplineSegment.java
@@ -20,19 +20,13 @@ package net.thenextlvl.gopaint.api.math.curve;
 
 import com.fastasyncworldedit.core.math.MutableBlockVector3;
 import com.sk89q.worldedit.math.BlockVector3;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Objects;
 
-@Getter
-@Setter
 @NullMarked
-@RequiredArgsConstructor
 public class BezierSplineSegment {
 
     private final MutableBlockVector3 startPoint;
@@ -48,6 +42,11 @@ public class BezierSplineSegment {
     private @Nullable Double xFlat, yFlat, zFlat;
 
     private MutableBlockVector3 result = MutableBlockVector3.at(0, 0, 0);
+
+    public BezierSplineSegment(MutableBlockVector3 startPoint, MutableBlockVector3 endPoint) {
+        this.startPoint = startPoint;
+        this.endPoint = endPoint;
+    }
 
     public void setX(double xFlat) {
         startPoint.mutX(xFlat);
@@ -103,5 +102,85 @@ public class BezierSplineSegment {
     private double calculatePoint(double factor, double startPoint, double intermediatePoint1, double intermediatePoint2, double endPoint) {
         return (Math.pow(1 - factor, 3) * startPoint) + (3 * Math.pow(1 - factor, 2) * factor * intermediatePoint1)
                + (3 * (1 - factor) * factor * factor * intermediatePoint2) + (Math.pow(factor, 3) * endPoint);
+    }
+
+    public MutableBlockVector3 getStartPoint() {
+        return startPoint;
+    }
+
+    public MutableBlockVector3 getEndPoint() {
+        return endPoint;
+    }
+
+    public MutableBlockVector3 getResult() {
+        return result;
+    }
+
+    public MutableBlockVector3 getIntermediatePoint1() {
+        return intermediatePoint1;
+    }
+
+    public MutableBlockVector3 getIntermediatePoint2() {
+        return intermediatePoint2;
+    }
+
+    public float getCoefficient1() {
+        return coefficient1;
+    }
+
+    public float getCoefficient2() {
+        return coefficient2;
+    }
+
+    public float getCoefficient3() {
+        return coefficient3;
+    }
+
+    public @Nullable Double getXFlat() {
+        return xFlat;
+    }
+
+    public @Nullable Double getYFlat() {
+        return yFlat;
+    }
+
+    public @Nullable Double getZFlat() {
+        return zFlat;
+    }
+
+    public void setResult(MutableBlockVector3 result) {
+        this.result = result;
+    }
+
+    public void setIntermediatePoint1(MutableBlockVector3 intermediatePoint1) {
+        this.intermediatePoint1 = intermediatePoint1;
+    }
+
+    public void setIntermediatePoint2(MutableBlockVector3 intermediatePoint2) {
+        this.intermediatePoint2 = intermediatePoint2;
+    }
+
+    public void setCoefficient1(float coefficient1) {
+        this.coefficient1 = coefficient1;
+    }
+
+    public void setCoefficient2(float coefficient2) {
+        this.coefficient2 = coefficient2;
+    }
+
+    public void setCoefficient3(float coefficient3) {
+        this.coefficient3 = coefficient3;
+    }
+
+    public void setXFlat(@Nullable Double xFlat) {
+        this.xFlat = xFlat;
+    }
+
+    public void setYFlat(@Nullable Double yFlat) {
+        this.yFlat = yFlat;
+    }
+
+    public void setZFlat(@Nullable Double zFlat) {
+        this.zFlat = zFlat;
     }
 }

--- a/api/src/main/java/net/thenextlvl/gopaint/api/model/SurfaceMode.java
+++ b/api/src/main/java/net/thenextlvl/gopaint/api/model/SurfaceMode.java
@@ -1,17 +1,11 @@
 package net.thenextlvl.gopaint.api.model;
 
 import com.fastasyncworldedit.core.function.mask.SurfaceMask;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.experimental.Accessors;
 import net.kyori.adventure.translation.Translatable;
 import net.thenextlvl.gopaint.api.brush.mask.VisibleMask;
 import org.jspecify.annotations.NullMarked;
 
-@Getter
 @NullMarked
-@RequiredArgsConstructor
-@Accessors(fluent = true)
 public enum SurfaceMode implements Translatable {
     /**
      * This enumeration represents that surface mode is disabled.
@@ -31,4 +25,13 @@ public enum SurfaceMode implements Translatable {
     VISIBLE("surface.mode.visible");
 
     private final String translationKey;
+
+    SurfaceMode(String translationKey) {
+        this.translationKey = translationKey;
+    }
+
+    @Override
+    public String translationKey() {
+        return translationKey;
+    }
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,14 +22,11 @@ repositories {
 }
 
 dependencies {
-    compileOnly("org.projectlombok:lombok:1.18.36")
     compileOnly("io.papermc.paper:paper-api:1.21.4-R0.1-SNAPSHOT")
 
     implementation("net.thenextlvl.core:adapters:2.0.1")
     implementation("org.bstats:bstats-bukkit:3.1.0")
     implementation(project(":api"))
-
-    annotationProcessor("org.projectlombok:lombok:1.18.36")
 }
 
 paper {

--- a/src/main/java/net/thenextlvl/gopaint/GoPaintPlugin.java
+++ b/src/main/java/net/thenextlvl/gopaint/GoPaintPlugin.java
@@ -7,8 +7,6 @@ import core.i18n.file.ComponentBundle;
 import core.io.IO;
 import core.paper.adapters.inventory.MaterialAdapter;
 import core.paper.adapters.key.KeyAdapter;
-import lombok.Getter;
-import lombok.experimental.Accessors;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
@@ -40,11 +38,9 @@ import java.util.Locale;
 import java.util.Set;
 
 @NullMarked
-@Accessors(fluent = true)
 public class GoPaintPlugin extends JavaPlugin implements GoPaintProvider {
-
     private final File translations = new File(getDataFolder(), "translations");
-    private final @Getter ComponentBundle bundle = new ComponentBundle(translations, audience ->
+    private final ComponentBundle bundle = new ComponentBundle(translations, audience ->
             audience instanceof Player player ? player.locale() : Locale.US)
             .register("messages", Locale.US)
             .register("messages_german", Locale.GERMANY)
@@ -53,8 +49,8 @@ public class GoPaintPlugin extends JavaPlugin implements GoPaintProvider {
                     Placeholder.component("prefix", bundle.component(Locale.US, "prefix"))
             )).build());
 
-    private final @Getter BrushController brushController = new CraftBrushController(this);
-    private final @Getter BrushRegistry brushRegistry = new CraftBrushRegistry(this);
+    private final BrushController brushController = new CraftBrushController(this);
+    private final BrushRegistry brushRegistry = new CraftBrushRegistry(this);
 
     private final FileIO<PluginConfig> configFile = new GsonFile<>(IO.of(getDataFolder(), "config.json"), new PluginConfig(
             new PluginConfig.BrushConfig(Material.FEATHER, Key.key("gopaint", "sphere_brush"), 100, 10, 50,
@@ -115,5 +111,17 @@ public class GoPaintPlugin extends JavaPlugin implements GoPaintProvider {
 
     public PluginConfig config() {
         return configFile.getRoot();
+    }
+
+    public ComponentBundle bundle() {
+        return this.bundle;
+    }
+
+    public BrushController brushController() {
+        return this.brushController;
+    }
+
+    public BrushRegistry brushRegistry() {
+        return this.brushRegistry;
     }
 }

--- a/src/main/java/net/thenextlvl/gopaint/GoPaintPlugin.java
+++ b/src/main/java/net/thenextlvl/gopaint/GoPaintPlugin.java
@@ -29,7 +29,6 @@ import org.bstats.bukkit.Metrics;
 import org.bukkit.Axis;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.ServicePriority;
 import org.bukkit.plugin.java.JavaPlugin;
@@ -58,7 +57,7 @@ public class GoPaintPlugin extends JavaPlugin implements GoPaintProvider {
     private final @Getter BrushRegistry brushRegistry = new CraftBrushRegistry(this);
 
     private final FileIO<PluginConfig> configFile = new GsonFile<>(IO.of(getDataFolder(), "config.json"), new PluginConfig(
-            new PluginConfig.BrushConfig(Material.FEATHER, new NamespacedKey("gopaint", "sphere_brush"), 100, 10, 50,
+            new PluginConfig.BrushConfig(Material.FEATHER, Key.key("gopaint", "sphere_brush"), 100, 10, 50,
                     Axis.Y, 50, 50, Set.of("disabled"), true, Material.SPONGE, true, SurfaceMode.EXPOSED,
                     List.of(Material.STONE)),
             new PluginConfig.ThicknessConfig(1, 5),

--- a/src/main/java/net/thenextlvl/gopaint/brush/CraftBrushController.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/CraftBrushController.java
@@ -18,7 +18,6 @@
  */
 package net.thenextlvl.gopaint.brush;
 
-import lombok.RequiredArgsConstructor;
 import net.kyori.adventure.key.Key;
 import net.thenextlvl.gopaint.GoPaintPlugin;
 import net.thenextlvl.gopaint.api.brush.BrushController;
@@ -43,10 +42,13 @@ import java.util.Optional;
 import java.util.UUID;
 
 @NullMarked
-@RequiredArgsConstructor
 public class CraftBrushController implements BrushController {
     private final Map<UUID, PlayerBrushSettings> playerBrushes = new HashMap<>();
     private final GoPaintPlugin plugin;
+
+    public CraftBrushController(GoPaintPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @Override
     public PlayerBrushSettings getBrushSettings(Player player) {

--- a/src/main/java/net/thenextlvl/gopaint/brush/CraftBrushController.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/CraftBrushController.java
@@ -98,21 +98,8 @@ public class CraftBrushController implements BrushController {
                 .filter(Objects::nonNull)
                 .toList();
 
-        return Optional.of(CraftItemBrushSettings.builder()
-                .brushSize(brushSize)
-                .maskEnabled(maskEnabled)
-                .surfaceMode(surfaceMode)
-                .brush(brush)
-                .chance(chance)
-                .thickness(thickness)
-                .fractureStrength(fractureStrength)
-                .angleDistance(angleDistance)
-                .falloffStrength(falloffStrength)
-                .mixingStrength(mixingStrength)
-                .angleHeightDifference(angleHeightDifference)
-                .axis(axis)
-                .mask(mask)
-                .blocks(blocks).build());
+        return Optional.of(new CraftItemBrushSettings(brush, mask, blocks, axis, surfaceMode, maskEnabled, brushSize,
+                chance, thickness, angleDistance, fractureStrength, falloffStrength, mixingStrength, angleHeightDifference));
     }
 
     @Override

--- a/src/main/java/net/thenextlvl/gopaint/brush/CraftBrushRegistry.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/CraftBrushRegistry.java
@@ -3,8 +3,8 @@ package net.thenextlvl.gopaint.brush;
 import com.google.common.base.Preconditions;
 import net.kyori.adventure.key.Key;
 import net.thenextlvl.gopaint.GoPaintPlugin;
-import net.thenextlvl.gopaint.api.brush.PatternBrush;
 import net.thenextlvl.gopaint.api.brush.BrushRegistry;
+import net.thenextlvl.gopaint.api.brush.PatternBrush;
 import net.thenextlvl.gopaint.brush.standard.*;
 import org.jspecify.annotations.NullMarked;
 

--- a/src/main/java/net/thenextlvl/gopaint/brush/pattern/SplinePattern.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/pattern/SplinePattern.java
@@ -7,21 +7,13 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.extent.Extent;
 import com.sk89q.worldedit.math.BlockVector3;
 import com.sk89q.worldedit.world.block.BlockState;
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.Accessors;
 import net.thenextlvl.gopaint.api.brush.pattern.BuildPattern;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import org.jspecify.annotations.NullMarked;
 
 import java.util.Objects;
 
-@Getter
-@Setter
 @NullMarked
-@RequiredArgsConstructor
-@Accessors(fluent = true, chain = false)
 public class SplinePattern implements BuildPattern {
     private final EditSession session;
     private final BlockVector3 position;
@@ -29,6 +21,13 @@ public class SplinePattern implements BuildPattern {
     private final BrushSettings settings;
 
     private int random;
+
+    public SplinePattern(EditSession session, BlockVector3 position, Player player, BrushSettings settings) {
+        this.session = session;
+        this.position = position;
+        this.player = player;
+        this.settings = settings;
+    }
 
     @Override
     public boolean apply(Extent extent, BlockVector3 get, BlockVector3 set) throws WorldEditException {
@@ -40,5 +39,29 @@ public class SplinePattern implements BuildPattern {
         var index = Math.clamp(random(), 0, settings().getBlocks().size() - 1);
         var block = BukkitAdapter.asBlockType(settings().getBlocks().get(index));
         return Objects.requireNonNull(block).getDefaultState();
+    }
+
+    public EditSession session() {
+        return this.session;
+    }
+
+    public BlockVector3 position() {
+        return this.position;
+    }
+
+    public Player player() {
+        return this.player;
+    }
+
+    public BrushSettings settings() {
+        return this.settings;
+    }
+
+    public int random() {
+        return this.random;
+    }
+
+    public void random(int random) {
+        this.random = random;
     }
 }

--- a/src/main/java/net/thenextlvl/gopaint/brush/setting/CraftItemBrushSettings.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/setting/CraftItemBrushSettings.java
@@ -18,8 +18,6 @@
  */
 package net.thenextlvl.gopaint.brush.setting;
 
-import lombok.Builder;
-import lombok.Getter;
 import net.thenextlvl.gopaint.api.brush.PatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.ItemBrushSettings;
 import net.thenextlvl.gopaint.api.model.SurfaceMode;
@@ -30,9 +28,7 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 import java.util.Random;
 
-@Getter
 @NullMarked
-@Builder(builderClassName = "Builder")
 public final class CraftItemBrushSettings implements ItemBrushSettings {
     private final PatternBrush brush;
     private final Material mask;
@@ -51,8 +47,96 @@ public final class CraftItemBrushSettings implements ItemBrushSettings {
 
     private static final Random random = new Random();
 
+    public CraftItemBrushSettings(PatternBrush brush, Material mask, List<Material> blocks, Axis axis, SurfaceMode surfaceMode,
+                           boolean maskEnabled, int brushSize, int chance, int thickness, int angleDistance,
+                           int fractureStrength, int falloffStrength, int mixingStrength, double angleHeightDifference) {
+        this.brush = brush;
+        this.mask = mask;
+        this.blocks = blocks;
+        this.axis = axis;
+        this.surfaceMode = surfaceMode;
+        this.maskEnabled = maskEnabled;
+        this.brushSize = brushSize;
+        this.chance = chance;
+        this.thickness = thickness;
+        this.angleDistance = angleDistance;
+        this.fractureStrength = fractureStrength;
+        this.falloffStrength = falloffStrength;
+        this.mixingStrength = mixingStrength;
+        this.angleHeightDifference = angleHeightDifference;
+    }
+
     @Override
     public Random getRandom() {
         return random;
+    }
+
+    public PatternBrush getBrush() {
+        return this.brush;
+    }
+
+    @Override
+    public Material getMask() {
+        return this.mask;
+    }
+
+    @Override
+    public List<Material> getBlocks() {
+        return this.blocks;
+    }
+
+    @Override
+    public Axis getAxis() {
+        return this.axis;
+    }
+
+    @Override
+    public SurfaceMode getSurfaceMode() {
+        return this.surfaceMode;
+    }
+
+    @Override
+    public boolean isMaskEnabled() {
+        return this.maskEnabled;
+    }
+
+    @Override
+    public int getBrushSize() {
+        return this.brushSize;
+    }
+
+    @Override
+    public int getChance() {
+        return this.chance;
+    }
+
+    @Override
+    public int getThickness() {
+        return this.thickness;
+    }
+
+    @Override
+    public int getAngleDistance() {
+        return this.angleDistance;
+    }
+
+    @Override
+    public int getFractureStrength() {
+        return this.fractureStrength;
+    }
+
+    @Override
+    public int getFalloffStrength() {
+        return this.falloffStrength;
+    }
+
+    @Override
+    public int getMixingStrength() {
+        return this.mixingStrength;
+    }
+
+    @Override
+    public double getAngleHeightDifference() {
+        return this.angleHeightDifference;
     }
 }

--- a/src/main/java/net/thenextlvl/gopaint/brush/setting/CraftPlayerBrushSettings.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/setting/CraftPlayerBrushSettings.java
@@ -21,7 +21,6 @@ package net.thenextlvl.gopaint.brush.setting;
 import core.paper.gui.AbstractGUI;
 import io.papermc.paper.datacomponent.DataComponentTypes;
 import io.papermc.paper.datacomponent.item.ItemLore;
-import lombok.Getter;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.JoinConfiguration;
@@ -57,7 +56,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
 
-@Getter
 @NullMarked
 public final class CraftPlayerBrushSettings implements PlayerBrushSettings {
     private static final Random random = new Random();
@@ -343,5 +341,77 @@ public final class CraftPlayerBrushSettings implements PlayerBrushSettings {
         setBrush(settings.getBrush());
         setMask(settings.getMask());
         setBlocks(settings.getBlocks());
+    }
+
+    public GoPaintPlugin getPlugin() {
+        return this.plugin;
+    }
+
+    public Player getPlayer() {
+        return this.player;
+    }
+
+    public boolean isEnabled() {
+        return this.enabled;
+    }
+
+    public int getBrushSize() {
+        return this.brushSize;
+    }
+
+    public int getChance() {
+        return this.chance;
+    }
+
+    public int getThickness() {
+        return this.thickness;
+    }
+
+    public int getFractureStrength() {
+        return this.fractureStrength;
+    }
+
+    public int getAngleDistance() {
+        return this.angleDistance;
+    }
+
+    public int getFalloffStrength() {
+        return this.falloffStrength;
+    }
+
+    public int getMixingStrength() {
+        return this.mixingStrength;
+    }
+
+    public double getAngleHeightDifference() {
+        return this.angleHeightDifference;
+    }
+
+    public Axis getAxis() {
+        return this.axis;
+    }
+
+    public boolean isMaskEnabled() {
+        return this.maskEnabled;
+    }
+
+    public SurfaceMode getSurfaceMode() {
+        return this.surfaceMode;
+    }
+
+    public PatternBrush getBrush() {
+        return this.brush;
+    }
+
+    public Material getMask() {
+        return this.mask;
+    }
+
+    public List<Material> getBlocks() {
+        return this.blocks;
+    }
+
+    public MainMenu getMainMenu() {
+        return this.mainMenu;
     }
 }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/AngleBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/AngleBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.AnglePattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class AngleBrush extends SpherePatternBrush {
     public AngleBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNmRlNDQ4ZjBkYmU3NmJiOGE4MzJjOGYzYjJhMDNkMzViZDRlMjc4NWZhNWU4Mjk4YzI2MTU1MDNmNDdmZmEyIn19fQ==",
-                new NamespacedKey("gopaint", "angle_brush")
+                Key.key("gopaint", "angle_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/BucketBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/BucketBrush.java
@@ -24,6 +24,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.PatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
@@ -31,7 +32,6 @@ import net.thenextlvl.gopaint.api.math.ConnectedBlocks;
 import net.thenextlvl.gopaint.api.math.Sphere;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.ShufflePattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -41,7 +41,7 @@ public class BucketBrush extends PatternBrush {
     public BucketBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNTAxOGI0NTc0OTM5Nzg4YTJhZDU1NTJiOTEyZDY3ODEwNjk4ODhjNTEyMzRhNGExM2VhZGI3ZDRjOTc5YzkzIn19fQ==",
-                new NamespacedKey("gopaint", "bucket_brush")
+                Key.key("gopaint", "bucket_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/DiskBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/DiskBrush.java
@@ -24,13 +24,13 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.PatternBrush;
+import net.thenextlvl.gopaint.api.brush.pattern.BuildPattern;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
-import net.thenextlvl.gopaint.api.brush.pattern.BuildPattern;
 import net.thenextlvl.gopaint.brush.pattern.ShufflePattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -40,7 +40,7 @@ public class DiskBrush extends PatternBrush {
     public DiskBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjFmMjgyNTBkMWU0MjBhNjUxMWIwMzk2NDg2OGZjYTJmNTYzN2UzYWJhNzlmNGExNjNmNGE4ZDYxM2JlIn19fQ==",
-                new NamespacedKey("gopaint", "disk_brush")
+                Key.key("gopaint", "disk_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/FractureBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/FractureBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.FracturePattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class FractureBrush extends SpherePatternBrush {
     public FractureBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMjNkZjczZWVlNjIyNGM1YzVkOTQ4ZDJhMzQ1ZGUyNWYyMDhjYmQ5YWY3MTA4Y2UxZTFiNjFhNTg2ZGU5OGIyIn19fQ==",
-                new NamespacedKey("gopaint", "fracture_brush")
+                Key.key("gopaint", "fracture_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/GradientBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/GradientBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.GradientPattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class GradientBrush extends SpherePatternBrush {
     public GradientBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNjA2MmRhM2QzYjhmMWZkMzUzNDNjYzI3OWZiMGZlNWNmNGE1N2I1YWJjNDMxZmJiNzhhNzNiZjJhZjY3NGYifX19",
-                new NamespacedKey("gopaint", "gradient_brush")
+                Key.key("gopaint", "gradient_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/OverlayBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/OverlayBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.OverlayPattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class OverlayBrush extends SpherePatternBrush {
     public OverlayBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZGYzMWQ2Zjk2NTRmODc0ZWE5MDk3YWRlZWEwYzk2OTk2ZTc4ZTNmZDM3NTRmYmY5ZWJlOTYzYWRhZDliZTRjIn19fQ==",
-                new NamespacedKey("gopaint", "overlay_brush")
+                Key.key("gopaint", "overlay_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/PaintBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/PaintBrush.java
@@ -26,6 +26,7 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.gopaint.api.brush.PatternBrush;
@@ -34,10 +35,14 @@ import net.thenextlvl.gopaint.api.math.Sphere;
 import net.thenextlvl.gopaint.api.math.curve.BezierSpline;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.SplinePattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 
 @NullMarked
 public class PaintBrush extends PatternBrush {
@@ -47,7 +52,7 @@ public class PaintBrush extends PatternBrush {
     public PaintBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvODBiM2E5ZGZhYmVmYmRkOTQ5YjIxN2JiZDRmYTlhNDg2YmQwYzNmMGNhYjBkMGI5ZGZhMjRjMzMyZGQzZTM0MiJ9fX0=",
-                new NamespacedKey("gopaint", "paint_brush")
+                Key.key("gopaint", "paint_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/SphereBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/SphereBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.ShufflePattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class SphereBrush extends SpherePatternBrush {
     public SphereBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvZmU5OGY0ODU2MDE0N2MwYTJkNGVkYzE3ZjZkOTg1ZThlYjVkOTRiZDcyZmM2MDc0NGE1YThmMmQ5MDVhMTgifX19",
-                new NamespacedKey("gopaint", "sphere_brush")
+                Key.key("gopaint", "sphere_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/SplatterBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/SplatterBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.SplatterPattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class SplatterBrush extends SpherePatternBrush {
     public SplatterBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvMzMzODI5MmUyZTY5ZjA5MDY5NGNlZjY3MmJiNzZmMWQ4Mzc1OGQxMjc0NGJiNmZmYzY4MzRmZGJjMWE5ODMifX19",
-                new NamespacedKey("gopaint", "splatter_brush")
+                Key.key("gopaint", "splatter_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/SprayBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/SprayBrush.java
@@ -23,12 +23,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.SprayPattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -38,7 +38,7 @@ public class SprayBrush extends SpherePatternBrush {
     public SprayBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvYjg4MGY3NjVlYTgwZGVlMzcwODJkY2RmZDk4MTJlZTM2ZmRhODg0ODY5MmE4NDFiZWMxYmJkOWVkNTFiYTIyIn19fQ==",
-                new NamespacedKey("gopaint", "spray_brush")
+                Key.key("gopaint", "spray_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/brush/standard/UnderlayBrush.java
+++ b/src/main/java/net/thenextlvl/gopaint/brush/standard/UnderlayBrush.java
@@ -5,12 +5,12 @@ import com.sk89q.worldedit.entity.Player;
 import com.sk89q.worldedit.function.pattern.Pattern;
 import com.sk89q.worldedit.math.BlockVector3;
 import net.kyori.adventure.audience.Audience;
+import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.Component;
 import net.thenextlvl.gopaint.api.brush.SpherePatternBrush;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.model.GoPaintProvider;
 import net.thenextlvl.gopaint.brush.pattern.UnderlayPattern;
-import org.bukkit.NamespacedKey;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
@@ -20,7 +20,7 @@ public class UnderlayBrush extends SpherePatternBrush {
     public UnderlayBrush(GoPaintProvider provider) {
         super(
                 "eyJ0ZXh0dXJlcyI6eyJTS0lOIjp7InVybCI6Imh0dHA6Ly90ZXh0dXJlcy5taW5lY3JhZnQubmV0L3RleHR1cmUvNzFlNTY1YzFlMDVhODIzZDgxNjMwMjY4N2E5OGQ1ZmUyZDA2NmFhMTkxNDMzNjg4NDRhMGM0MzAyNzYyNDljMyJ9fX0=",
-                new NamespacedKey("gopaint", "underlay_brush")
+                Key.key("gopaint", "underlay_brush")
         );
         this.provider = provider;
     }

--- a/src/main/java/net/thenextlvl/gopaint/command/GoPaintCommand.java
+++ b/src/main/java/net/thenextlvl/gopaint/command/GoPaintCommand.java
@@ -7,7 +7,6 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.Commands;
 import io.papermc.paper.command.brigadier.argument.ArgumentTypes;
 import io.papermc.paper.plugin.lifecycle.event.types.LifecycleEvents;
-import lombok.RequiredArgsConstructor;
 import net.kyori.adventure.key.Key;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;
 import net.thenextlvl.gopaint.GoPaintPlugin;
@@ -20,9 +19,12 @@ import org.jspecify.annotations.NullMarked;
 import java.util.List;
 
 @NullMarked
-@RequiredArgsConstructor
 public class GoPaintCommand {
     private final GoPaintPlugin plugin;
+
+    public GoPaintCommand(GoPaintPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     public void register() {
         var command = Commands.literal("gopaint")

--- a/src/main/java/net/thenextlvl/gopaint/listener/ConnectListener.java
+++ b/src/main/java/net/thenextlvl/gopaint/listener/ConnectListener.java
@@ -18,7 +18,6 @@
  */
 package net.thenextlvl.gopaint.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.gopaint.GoPaintPlugin;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -27,9 +26,12 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public class ConnectListener implements Listener {
     private final GoPaintPlugin plugin;
+
+    public ConnectListener(GoPaintPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onPlayerQuit(PlayerQuitEvent event) {

--- a/src/main/java/net/thenextlvl/gopaint/listener/InteractListener.java
+++ b/src/main/java/net/thenextlvl/gopaint/listener/InteractListener.java
@@ -24,7 +24,6 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldedit.bukkit.BukkitPlayer;
 import com.sk89q.worldedit.function.mask.MaskIntersection;
 import com.sk89q.worldedit.session.request.Request;
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.gopaint.GoPaintPlugin;
 import net.thenextlvl.gopaint.api.brush.setting.BrushSettings;
 import net.thenextlvl.gopaint.api.brush.setting.PlayerBrushSettings;
@@ -36,9 +35,12 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public final class InteractListener implements Listener {
     private final GoPaintPlugin plugin;
+
+    public InteractListener(GoPaintPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onClick(PlayerInteractEvent event) {

--- a/src/main/java/net/thenextlvl/gopaint/listener/InventoryListener.java
+++ b/src/main/java/net/thenextlvl/gopaint/listener/InventoryListener.java
@@ -18,10 +18,17 @@
  */
 package net.thenextlvl.gopaint.listener;
 
-import lombok.RequiredArgsConstructor;
 import net.thenextlvl.gopaint.GoPaintPlugin;
 import net.thenextlvl.gopaint.api.model.SurfaceMode;
-import net.thenextlvl.gopaint.brush.standard.*;
+import net.thenextlvl.gopaint.brush.standard.AngleBrush;
+import net.thenextlvl.gopaint.brush.standard.DiskBrush;
+import net.thenextlvl.gopaint.brush.standard.FractureBrush;
+import net.thenextlvl.gopaint.brush.standard.GradientBrush;
+import net.thenextlvl.gopaint.brush.standard.OverlayBrush;
+import net.thenextlvl.gopaint.brush.standard.PaintBrush;
+import net.thenextlvl.gopaint.brush.standard.SplatterBrush;
+import net.thenextlvl.gopaint.brush.standard.SprayBrush;
+import net.thenextlvl.gopaint.brush.standard.UnderlayBrush;
 import net.thenextlvl.gopaint.menu.MainMenu;
 import org.bukkit.Axis;
 import org.bukkit.entity.Player;
@@ -34,9 +41,12 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import org.jspecify.annotations.NullMarked;
 
 @NullMarked
-@RequiredArgsConstructor
 public final class InventoryListener implements Listener {
     private final GoPaintPlugin plugin;
+
+    public InventoryListener(GoPaintPlugin plugin) {
+        this.plugin = plugin;
+    }
 
     @EventHandler(priority = EventPriority.LOWEST, ignoreCancelled = true)
     public void menuClick(InventoryClickEvent event) {

--- a/src/main/java/net/thenextlvl/gopaint/menu/BrushesMenu.java
+++ b/src/main/java/net/thenextlvl/gopaint/menu/BrushesMenu.java
@@ -3,7 +3,6 @@ package net.thenextlvl.gopaint.menu;
 import core.paper.gui.PaginatedGUI;
 import core.paper.item.ActionItem;
 import core.paper.item.ItemBuilder;
-import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.thenextlvl.gopaint.api.brush.PatternBrush;
@@ -18,7 +17,7 @@ import java.util.stream.IntStream;
 
 @NullMarked
 public class BrushesMenu extends PaginatedGUI<GoPaintProvider, PatternBrush> {
-    private final @Getter Pagination pagination = new Pagination(
+    private final Pagination pagination = new Pagination(
             IntStream.range(0, getSize() - 9).toArray(),
             getSize() - 6,
             getSize() - 4
@@ -58,5 +57,10 @@ public class BrushesMenu extends PaginatedGUI<GoPaintProvider, PatternBrush> {
     @Override
     public Collection<PatternBrush> getElements() {
         return plugin.brushRegistry().getBrushes().toList();
+    }
+
+    @Override
+    public Pagination getPagination() {
+        return pagination;
     }
 }

--- a/src/main/java/net/thenextlvl/gopaint/menu/MainMenu.java
+++ b/src/main/java/net/thenextlvl/gopaint/menu/MainMenu.java
@@ -2,7 +2,6 @@ package net.thenextlvl.gopaint.menu;
 
 import core.paper.gui.AbstractGUI;
 import core.paper.item.ItemBuilder;
-import lombok.Getter;
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.format.TextDecoration;
@@ -34,7 +33,7 @@ public class MainMenu extends AbstractGUI {
     private final PlayerBrushSettings settings;
     private final GoPaintPlugin plugin;
 
-    private final @Getter Inventory inventory;
+    private final Inventory inventory;
 
     public MainMenu(GoPaintPlugin plugin, PlayerBrushSettings settings, Player owner) {
         super(owner, plugin.bundle().component(owner, "menu.main.title"));
@@ -324,5 +323,9 @@ public class MainMenu extends AbstractGUI {
 
         inventory.setItem(2, orangeGlassPane);
         inventory.setItem(20, orangeGlassPane);
+    }
+
+    public Inventory getInventory() {
+        return this.inventory;
     }
 }


### PR DESCRIPTION
Lombok annotations were removed, and equivalent methods were manually implemented across affected classes. This simplifies the codebase by eliminating the need for Lombok while preserving functionality. Gradle build script dependencies were updated accordingly.